### PR TITLE
Fix error handling for xml to json and, mulitpart parser

### DIFF
--- a/src/BodyParser.js
+++ b/src/BodyParser.js
@@ -67,7 +67,7 @@ exports.xmlBodyParser = function(req, res, next) {
         req.body = xmlParser.toJson(bodyStr, xmlOptions);
         next();
       } catch (err) {
-        res.status(400).send({ status: "FAILURE", responseCode: 'XML_PARSING_ERROR', responseMessage: 'Failed while parsing XML Request' });
+        next(new Error('XML_PARSING_ERROR'));
       }
     });
   } else {
@@ -82,7 +82,7 @@ exports.mutipartBodyParser = function(options) {
       req.body = {};
       form.parse(req, function(err, fields, files) {
         if(err) {
-          res.status(400).send({ status: "FAILURE", responseCode: 'MUTIPART_PARSING_ERROR', responseMessage: 'Failed while parsing Mutipart-Form-Data Request' });
+          next(new Error('MUTIPART_PARSING_ERROR'));
         } else {
           try {
             var keys = Object.keys(fields);
@@ -90,7 +90,7 @@ exports.mutipartBodyParser = function(options) {
             req.body = fields;
             next();
           } catch (error) {
-            res.status(400).send({ status: "FAILURE", responseCode: 'MUTIPART_PARSING_ERROR', responseMessage: 'Failed while parsing Mutipart-Form-Data Request' });
+            next(new Error('MUTIPART_PARSING_ERROR'));
           }
         }
       });


### PR DESCRIPTION
Both the handlers were setting the response code as `400` and sending
the response straight from the middleware. This causes issues in
debugging as these errors are never logged anywhere, and the only place
where we can find a trace of these is in nginx access logs etc., where the error
messages are lost and we can only see the response codes.

Since ExpressJS follows error first callback patterns, we can pass the
caught erro/exception to `next` as the first argument, and let the end-user
decide how to handle the error.

This follows the pattern followed by the original `body-parser`
wherein `next` is called with an error if parsing fails for some reason.

Ideally middleware should only be transforming/analysing requests and
not serving them, hence moving the response handling out of the
body-parser.

References #3 